### PR TITLE
Add utility to support json stringify/parse with JSONBigInt 

### DIFF
--- a/tsp-typescript-client/src/utils/jsonbig-utils.test.ts
+++ b/tsp-typescript-client/src/utils/jsonbig-utils.test.ts
@@ -1,0 +1,66 @@
+// tslint:disable: no-unused-expression
+
+import { Experiment } from '../models/experiment';
+import { Identifier } from '../models/identifier';
+import { Query } from '../models/query/query';
+import { HttpRequest, HttpResponse, RestClient } from '../protocol/rest-client';
+import { FixtureSet } from '../protocol/test-utils';
+import { TspClient } from '../protocol/tsp-client';
+import { JSONBigUtils } from './jsonbig-utils';
+
+describe('JSONBigUtils tests', () => {
+
+  const client = new TspClient('not-relevant');
+  const httpRequestMock = jest.fn<Promise<HttpResponse>, [req: HttpRequest]>();
+
+  let fixtures: FixtureSet;
+
+  beforeAll(async () => {
+    fixtures = await FixtureSet.fromFolder(__dirname, '../../fixtures/tsp-client');
+    RestClient['httpRequest'] = httpRequestMock;
+  });
+
+  beforeEach(() => {
+    httpRequestMock.mockReset();
+    httpRequestMock.mockResolvedValue({ text: '', status: 404, statusText: 'Not found' });
+  });
+
+  it('testJSONBigUtils-with-normalizer', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('create-experiment-0.json'));
+    const response = await client.createExperiment(new Query({}));
+    const experiment = response.getModel()!;
+
+    const input = JSONBigUtils.stringify(experiment);
+    const experiment2: Experiment = JSONBigUtils.parse(input, Experiment);
+
+    expect(experiment).toEqual(experiment2);
+  });
+
+  it('testJSONBigUtils-no-normalizer', async () => {
+    const inputObj = 'hallo';
+    const input = JSONBigUtils.stringify(inputObj);
+    const output = JSONBigUtils.parse<string>(input);
+    expect(typeof output).toEqual('string');
+
+    let bigIntObj = BigInt("1234567890123456789");
+    const bigIntInput = JSONBigUtils.stringify(bigIntObj);
+    const bigIntOutput = JSONBigUtils.parse<bigint>(bigIntInput);
+    expect(typeof bigIntOutput).toEqual('bigint');
+
+    const idObj: Identifier = {
+      version: "version",
+      buildTime: "buildTime",
+      os: "os",
+      osArch: "osArch",
+      osVersion: "osVersion",
+      cpuCount: "cpuCount",
+      maxMemory: "maxMemory",
+      launcherName: "launcherName",
+      productId: "productId"
+    };
+    const idInput = JSONBigUtils.stringify(idObj);
+    const idOutput: Identifier = JSONBigUtils.parse<Identifier>(idInput);
+    expect(typeof idOutput).toEqual('object');
+    expect(idOutput).toEqual(idObj);
+  });
+});

--- a/tsp-typescript-client/src/utils/jsonbig-utils.ts
+++ b/tsp-typescript-client/src/utils/jsonbig-utils.ts
@@ -1,0 +1,48 @@
+import { Normalizer } from '../protocol/serialization';
+import JSONBigConfig = require('json-bigint');
+
+const JSONBig = JSONBigConfig({
+    useNativeBigInt: true,
+});
+
+/**
+ * Rest client helper to make request.
+ * The request response status code indicates if the request is successful.
+ * The json object in the response may be undefined when an error occurs.
+ */
+export class JSONBigUtils {
+
+    static parse<T>(url: string): T;
+    static parse<T>(input: string, normalizer?: Normalizer<T>): T;
+    /**
+     * Parse JSON-encoded data using a normalizer. It will create `BigInt' 
+     * values instead of `number` as defined by normalizer.
+     * 
+     * @template T is the expected type of the json object returned
+     * @param input Input JSON string to deserialize
+     * @param normalizer Normalizer to create type T
+     */
+    public static parse<T>(input: string, normalizer?: Normalizer<T>) {
+        try {
+            const parsed = JSONBig.parse(input);
+            try {
+                if (normalizer) {
+                    return normalizer(parsed) as T;
+                }
+                return parsed as T;
+            } catch (err) {
+                console.log('Error normalizing parsed input string: ' + err.toString());
+            }
+        } catch (err) {
+            console.log('Error parsing input string: ' + JSON.stringify(err));
+        }
+        return null;
+    }
+
+    /**
+     * Stringify JS objects. Can stringify `BigInt` values.
+     */
+    public static stringify(data: any): string {
+        return JSONBig.stringify(data);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Add utility to support json stringify/parse with JSONBigInt.

Example Usages:
```javascript
// Usage with normalizer
import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
let input = JSONBigUtils.stringify(experiment);
let output: Experiment = JSONBigUtils.parse(input, Experiment);

// Usage no normalizer
input = JSONBigUtils.stringify(inputObj);
output = JSONBigUtils.parse<string>(input);
input = JSONBigUtils.stringify(BigInt("1234567890123456789"));
output = JSONBigUtils.parse<bigint>(bigIntInput);
```

fixes #57
<!-- Include relevant issues and describe how they are addressed. -->

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Unit tests including new tests for utility successful.

### Follow-ups
N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>