### PR TITLE
Add Vulnerability Reporting Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Vulnerability Reporting Policy
+
+If you think or suspect that you have discovered a new security vulnerability in this project, please __do not__ disclose it on GitHub, e.g. in an issue, a PR, or a discussion. Any such disclosure will be removed/deleted on sight, to promote orderly disclosure, as per the [Eclipse Foundation Vulnerability Reporting Policy][policy].
+
+Instead, please report any potential vulnerability to the Eclipse Foundation [Security Team][security]. Make sure to provide a concise description of the issue, a CWE, and other supporting information.
+
+[policy]: https://www.eclipse.org/security/policy.php
+[security]: https://www.eclipse.org/security


### PR DESCRIPTION
This commit adds SECURITY.md to inform contributors and users of the Vulnerability Reporting Policy for the tsp-python-client.