### PR TITLE
Replace theia-ide with eclipse-cdt-cloud references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ yarn test --coverage --collectCoverageFrom='src/**/*.ts'
 ```
 
 [contributing]: CONTRIBUTING.md
-[protocol]: https://github.com/theia-ide/trace-server-protocol
+[protocol]: https://github.com/eclipse-cdt-cloud/trace-server-protocol

--- a/tsp-typescript-client/README.md
+++ b/tsp-typescript-client/README.md
@@ -4,5 +4,5 @@ A client-side implementation, in typescript, of the Trace Server Protocol (TSP).
 
 ## Additional Information
 
-- [Trace Server Protocol (TSP)](https://github.com/theia-ide/theia-trace-extension): Protocol specification.
-- [Theia Trace Extension](https://github.com/theia-ide/theia-trace-extension): An reference application that uses the tsp-typescript-client to communicate to a trace-server back-end.
+- [Trace Server Protocol (TSP)](https://github.com/eclipse-cdt-cloud/theia-trace-extension): Protocol specification.
+- [Theia Trace Extension](https://github.com/eclipse-cdt-cloud/theia-trace-extension): An reference application that uses the tsp-typescript-client to communicate to a trace-server back-end.


### PR DESCRIPTION
The repository has been moved to the Eclipse cdt-cloud project and is
now located under the eclipse-cdt-cloud GitHub organization.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>