### PR TITLE
Add metadata to timegraph deserializer

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/fetch-timegraph-tree-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-timegraph-tree-0.json
@@ -10,7 +10,12 @@
 				],
 				"start": 1234567890123456789,
 				"end": 9876543210987654321,
-				"hasData": true
+				"hasData": true,
+				"metadata": {
+					"pid": [1234, 7777],
+					"tid": [5678],
+					"exec_name": ["name"]
+				}
 			}
 		],
 		"headers": [

--- a/tsp-typescript-client/src/models/entry.ts
+++ b/tsp-typescript-client/src/models/entry.ts
@@ -7,6 +7,7 @@ export const Entry = createNormalizer<Entry>({
     style: {
         values: undefined,
     },
+    metadata: undefined,
 });
 
 /**
@@ -38,6 +39,11 @@ export interface Entry {
      * The style map can be obtained by using the style endpoint.
      */
     style?: OutputElementStyle;
+
+    /**
+     * Metadata
+     */
+    metadata?: { [key: string]: any };
 }
 
 /**

--- a/tsp-typescript-client/src/models/timegraph.ts
+++ b/tsp-typescript-client/src/models/timegraph.ts
@@ -8,6 +8,7 @@ export const TimeGraphEntry = createNormalizer<TimeGraphEntry>({
     parentId: assertNumber,
     start: BigInt,
     style: OutputElementStyle,
+    metadata: undefined,
 });
 
 /**

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -279,6 +279,25 @@ describe('TspClient Deserialization', () => {
       expect(typeof entry.end).toEqual('bigint');
       expect(typeof entry.id).toEqual('number');
       expect(typeof entry.start).toEqual('bigint');
+      const metadata = entry.metadata;
+      expect(metadata).toBeDefined();
+      const pids = metadata?.pid;
+      expect(pids).toBeDefined();
+      expect(pids).toHaveLength(2);
+      expect(typeof pids[0]).toEqual('number');
+      expect(typeof pids[1]).toEqual('number');
+      expect(pids[0]).toEqual(1234)
+      expect(pids[1]).toEqual(7777)
+      const tids = metadata?.tid;
+      expect(tids).toBeDefined();
+      expect(tids).toHaveLength(1);
+      expect(typeof tids[0]).toEqual('number');
+      expect(tids[0]).toEqual(5678)
+      const exec = metadata?.exec_name;
+      expect(exec).toBeDefined();
+      expect(exec).toHaveLength(1);
+      expect(typeof exec[0]).toEqual('string');
+      expect(exec[0]).toEqual('name')
     }
   });
 


### PR DESCRIPTION
This PR adds support for metadata in the timegraph deserializer. It includes also unit tests to verify this change.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>
Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
