### PR TITLE
Update package.json to cdt-cloud url/homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/theia-ide/tsp-typescript-client"
+    "url": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client"
   },
   "bugs": {
-    "url": "https://github.com/theia-ide/tsp-typescript-client/issues"
+    "url": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client/issues"
   },
-  "homepage": "https://github.com/theia-ide/tsp-typescript-client",
+  "homepage": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client",
   "files": [
     "lib",
     "src"


### PR DESCRIPTION
Update with the most up-to-date url the
package.json files in the project.

Probably was forgotten when migrating the
project to eclipse-cdt-cloud in github.

Signed-off-by: Francesco Robino <francesco.robino@ericsson.com>