### PR TITLE
Add XyEntry API to deserialize XY entry the specific attribute isDefault

### DIFF
--- a/tsp-typescript-client/src/models/xy.ts
+++ b/tsp-typescript-client/src/models/xy.ts
@@ -1,4 +1,5 @@
 import { array, assertNumber, createNormalizer, toBigInt } from '../protocol/serialization';
+import { Entry } from './entry';
 import { OutputElementStyle } from "./styles";
 
 export const XYSeries = createNormalizer<XYSeries>({
@@ -8,6 +9,13 @@ export const XYSeries = createNormalizer<XYSeries>({
     tags: array(assertNumber),
     style: OutputElementStyle,
 });
+
+export interface XyEntry extends Entry {
+    /**
+     * Flag whether or not the entry is a default entry and its xy data should be fetched by default
+     */
+    isDefault?: boolean;
+}
 
 /**
  * Represent a XY series and its values

--- a/tsp-typescript-client/src/protocol/tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.ts
@@ -1,6 +1,6 @@
 import { Query } from '../models/query/query';
 import { GenericResponse } from '../models/response/responses';
-import { XYModel } from '../models/xy';
+import { XyEntry, XYModel } from '../models/xy';
 import { TimeGraphEntry, TimeGraphArrow, TimeGraphModel } from '../models/timegraph';
 import { AnnotationCategoriesModel, AnnotationModel } from '../models/annotation';
 import { TableModel, ColumnHeaderEntry } from '../models/table';
@@ -147,7 +147,7 @@ export class TspClient {
         expUUID: string,
         outputID: string,
         parameters: Query,
-    ): Promise<TspClientResponse<GenericResponse<EntryModel<Entry>>>> {
+    ): Promise<TspClientResponse<GenericResponse<EntryModel<XyEntry>>>> {
         const url = this.baseUrl + '/experiments/' + expUUID + '/outputs/XY/' + outputID + '/tree';
         return RestClient.post(url, parameters, GenericResponse(EntryModel(Entry)));
     }


### PR DESCRIPTION
Corresponding: TSP specitication: https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/85
Contributes to https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues/786

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>