### PR TITLE
Fix publish to NPM

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -64,7 +64,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         node: [16.x]
 
     steps:

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,6 @@
     "run": {
       "stream": true
     }
-  }
+  },
+  "verifyAccess": false
 }


### PR DESCRIPTION
- [lerna] option verifyAccess to false
  This will permit publishing to npm using an automation token.
  https://github.com/lerna/lerna/issues/2788#issuecomment-776726711

- Use actions/setup-node@v3 instead of actions/setup-node@v1
- Update to Ubuntu 20.04 in ci-cd builds

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
