### PR TITLE
Add support for configuration service end-points

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/configuration-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/configuration-0.json
@@ -1,0 +1,9 @@
+{
+	"id": "my-config-1-id",
+	"name": "My configuration 1",
+	"description": "My configuration 1 description",
+	"sourceTypeId": "my-source-type-1-id",
+	"parameters": {
+		"path": "/home/user/tmp"
+	}
+}

--- a/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
@@ -1,0 +1,18 @@
+[
+	{
+		"id": "my-source-type-1-id",
+		"name": "My configuration source 1",
+		"description": "My configuration source 1 description",
+		"configParamDescriptors": [ 
+			{
+				"keyName": "path",
+				"description": "path description",
+				"dataType": "STRING",
+				"isRequired": "True"
+ 			},
+			{
+				"keyName": "test1"
+  		    }
+		]
+	}
+]

--- a/tsp-typescript-client/fixtures/tsp-client/fetch-configurations-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-configurations-0.json
@@ -1,0 +1,16 @@
+[
+	{
+		"id": "my-config-1-id",
+		"name": "My configuration 1",
+		"description": "My configuration 1 description",
+		"sourceTypeId": "my-source-type-1-id",
+		"parameters": {
+			"path": "/home/user/tmp"
+		}
+	},
+	{
+		"id": "my-config-2-id",
+		"name": "My configuration 2",
+		"sourceTypeId": "my-source-type-1-id"
+	}
+]

--- a/tsp-typescript-client/src/models/configuration-source.ts
+++ b/tsp-typescript-client/src/models/configuration-source.ts
@@ -1,0 +1,51 @@
+
+/**
+ * Model of a configuration source type
+ */
+export interface ConfigurationSourceType {
+    /**
+     * Unique identifier of the configuration source type
+     */
+    id: string;
+
+    /**
+     * The name of the configuration source type
+     */
+    name: string;
+
+    /**
+     * A short description of this configuration source type.
+     */
+    description?: string;
+
+    /**
+     * A list of query parameter keys to be passed when creating
+     * configuration instance of this type
+     */
+    configParamDescriptors: ConfigParamDescriptor[];
+}
+
+/**
+ * Model of a configuration parameter descriptor
+ */
+export interface ConfigParamDescriptor {
+    /**
+     * The unique name of the key
+     */
+    keyName: string;
+
+    /**
+     * A short description.
+     */
+    description?: string;
+
+    /**
+     * The data type string, e.g. use NUMBER for numbers, or STRING as strings
+     */
+    dataType?: string;
+
+    /**
+     * If parameter needs to in the query parameters or not. Default is false. 
+     */
+    isRequired?: boolean;
+}

--- a/tsp-typescript-client/src/models/configuration.ts
+++ b/tsp-typescript-client/src/models/configuration.ts
@@ -1,0 +1,56 @@
+
+/**
+ * Model of a configuration instance
+ */
+export interface Configuration {
+    /**
+     * Unique identifier of the configuration
+     */
+    id: string;
+
+    /**
+     * The name of the configuration
+     */
+    name: string;
+
+    /**
+     * A short description of this configuration
+     */
+    description?: string;
+
+    /**
+     * the configuration source type ID
+     */
+    sourceTypeId: string;
+
+    /**
+     * Optional informational map of parameters to return. 
+     * Can be used to show more details to users of the configuration instance.
+     */
+    parameters?: Record<string, any>;
+}
+
+/**
+ * Model of a configuration parameter descriptor
+ */
+export interface ConfigParamDescriptor {
+    /**
+     * The unique name of the key
+     */
+    keyName: string;
+
+    /**
+     * A short description.
+     */
+    description?: string;
+
+    /**
+     * The data type string, e.g. use NUMBER for numbers, or STRING as strings
+     */
+    dataType?: string;
+
+    /**
+     * If parameter needs to in the query parameters or not. Default is false. 
+     */
+    isRequired?: boolean;
+}

--- a/tsp-typescript-client/src/protocol/http-tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/http-tsp-client.ts
@@ -1,28 +1,30 @@
-import { Query } from "../models/query/query";
-import { GenericResponse } from "../models/response/responses";
-import { XyEntry, XYModel } from "../models/xy";
-import {
-    TimeGraphEntry,
-    TimeGraphArrow,
-    TimeGraphModel,
-} from "../models/timegraph";
 import {
     AnnotationCategoriesModel,
     AnnotationModel,
 } from "../models/annotation";
-import { TableModel, ColumnHeaderEntry } from "../models/table";
-import { Trace } from "../models/trace";
-import { RestClient } from "./rest-client";
+import { Configuration } from "../models/configuration";
+import { ConfigurationSourceType } from "../models/configuration-source";
+import { DataTreeEntry } from "../models/data-tree";
+import { Entry, EntryModel } from "../models/entry";
 import { Experiment } from "../models/experiment";
-import { OutputDescriptor } from "../models/output-descriptor";
-import { EntryModel, Entry } from "../models/entry";
-import { TspClientResponse } from "./tsp-client-response";
-import { OutputStyleModel } from "../models/styles";
 import { HealthStatus } from "../models/health";
 import { MarkerSet } from "../models/markerset";
+import { OutputDescriptor } from "../models/output-descriptor";
+import { Query } from "../models/query/query";
+import { GenericResponse } from "../models/response/responses";
+import { OutputStyleModel } from "../models/styles";
+import { ColumnHeaderEntry, TableModel } from "../models/table";
+import {
+    TimeGraphArrow,
+    TimeGraphEntry,
+    TimeGraphModel,
+} from "../models/timegraph";
+import { Trace } from "../models/trace";
+import { XYModel, XyEntry } from "../models/xy";
+import { RestClient } from "./rest-client";
 import { array } from "./serialization";
-import { DataTreeEntry } from "../models/data-tree";
 import { ITspClient } from "./tsp-client";
+import { TspClientResponse } from "./tsp-client-response";
 
 /**
  * Http request implementation, using the RestClient helper, of the Trace Server Protocol client
@@ -515,5 +517,79 @@ export class HttpTspClient implements ITspClient {
     public async checkHealth(): Promise<TspClientResponse<HealthStatus>> {
         const url = this.baseUrl + "/health";
         return RestClient.get(url);
+    }
+
+    /**
+     * Fetch all configuration source types
+     * @returns Generic response with the model
+     */
+    fetchConfigurationSourceTypes(): Promise<TspClientResponse<ConfigurationSourceType[]>> {
+        const url = this.baseUrl + "/config/types";
+        return RestClient.get(url);
+    }
+
+    /**
+     * Fetch configuration source type for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    fetchConfigurationSourceType(typeId: string): Promise<TspClientResponse<ConfigurationSourceType>> {
+        const url = this.baseUrl + "/config/types/" + typeId;
+        return RestClient.get(url);
+    }
+
+    /**
+     * Fetch all configurations for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    fetchConfigurations(typeId: string): Promise<TspClientResponse<Configuration[]>> {
+        const url = this.baseUrl + "/config/types/" + typeId + "/configs";
+        return RestClient.get(url);
+    }
+
+    /**
+     * Fetch a configuration by ID for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    fetchConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>> {
+        const url = this.baseUrl + "/config/types/" + typeId + "/configs/" + configId;
+        return RestClient.get(url);
+    }
+
+    /**
+     * Create a configuration for a given type ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    createConfiguration(typeId: string, parameters: Query): Promise<TspClientResponse<Configuration>> {
+        const url = this.baseUrl + "/config/types/" + typeId;
+        return RestClient.post(url, parameters);
+    }
+
+    /**
+     * Update a configuration for a given type ID, config ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    updateConfiguration(typeId: string, configId: string, parameters: Query): Promise<TspClientResponse<Configuration>> {
+        const url = this.baseUrl + "/config/types/" + typeId + "/configs/" + configId;
+        return RestClient.put(url, parameters);
+    }
+
+    /**
+     * Delete a configuration for a given type ID and config ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    deleteConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>> {
+        const url = this.baseUrl + "/config/types/" + typeId + "/configs/" + configId;
+        return RestClient.delete(url);
     }
 }

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -384,4 +384,98 @@ describe('HttpTspClient Deserialization', () => {
     expect(typeof trace.nbEvents).toEqual('number');
     expect(typeof trace.start).toEqual('bigint');
   });
+
+  it('configurationSourceTypes', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('fetch-configuration-sources-0.json'));
+    const response = await client.fetchConfigurationSourceTypes();
+    const sourceTypes = response.getModel()!;
+
+    expect(sourceTypes).toHaveLength(1);
+    expect(sourceTypes[0].name).toEqual('My configuration source 1');
+    expect(sourceTypes[0].description).toEqual('My configuration source 1 description');
+    expect(sourceTypes[0].id).toEqual('my-source-type-1-id');
+    expect(sourceTypes[0].configParamDescriptors).toHaveLength(2);
+
+    expect(sourceTypes[0].configParamDescriptors[0].keyName).toEqual('path');
+    expect(sourceTypes[0].configParamDescriptors[0].description).toEqual('path description');
+    expect(sourceTypes[0].configParamDescriptors[0].dataType).toEqual('STRING');
+    expect(sourceTypes[0].configParamDescriptors[0].isRequired).toBeTruthy();
+
+    expect(sourceTypes[0].configParamDescriptors[1].keyName).toEqual('test1');
+    expect(sourceTypes[0].configParamDescriptors[1].description).toBeUndefined();
+    expect(sourceTypes[0].configParamDescriptors[1].dataType).toBeUndefined();
+    expect(sourceTypes[0].configParamDescriptors[1].isRequired).toBeUndefined();
+  });
+
+  it('configurations', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('fetch-configurations-0.json'));
+    const response = await client.fetchConfigurations("my-config-1-id");
+    const configs = response.getModel()!;
+
+    expect(configs).toHaveLength(2);
+    expect(configs[0].name).toEqual('My configuration 1');
+    expect(configs[0].description).toEqual('My configuration 1 description');
+    expect(configs[0].id).toEqual('my-config-1-id');
+    expect(configs[0].parameters).toBeDefined();
+    expect(configs[0].parameters?.path).toBeDefined();
+    expect(configs[0].parameters?.path).toEqual('/home/user/tmp');
+
+    expect(configs[1].name).toEqual('My configuration 2');
+    expect(configs[1].description).toBeUndefined()
+    expect(configs[1].id).toEqual('my-config-2-id');
+    expect(configs[1].parameters).toBeUndefined();
+  });
+
+  it('configuration', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('configuration-0.json'));
+    const response = await client.fetchConfiguration("my-source-type-1-id", "my-config-1-id");
+    const config = response.getModel()!;
+    
+    expect(config.name).toEqual('My configuration 1');
+    expect(config.description).toEqual('My configuration 1 description');
+    expect(config.id).toEqual('my-config-1-id');
+    expect(config.parameters).toBeDefined();
+    expect(config.parameters?.path).toBeDefined();
+    expect(config.parameters?.path).toEqual('/home/user/tmp');
+  });
+
+  it('createConfiguration', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('configuration-0.json'));
+    const response = await client.createConfiguration("my-source-type-1-id", new Query({}));
+    const config = response.getModel()!;
+
+    expect(config.name).toEqual('My configuration 1');
+    expect(config.description).toEqual('My configuration 1 description');
+    expect(config.id).toEqual('my-config-1-id');
+    expect(config.parameters).toBeDefined();
+    expect(config.parameters?.path).toBeDefined();
+    expect(config.parameters?.path).toEqual('/home/user/tmp');
+  });
+
+  it('updateConfiguration', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('configuration-0.json'));
+    const response = await client.updateConfiguration("my-source-type-1-id", "my-config-1-id", new Query({}));
+    const config = response.getModel()!;
+
+    expect(config.name).toEqual('My configuration 1');
+    expect(config.description).toEqual('My configuration 1 description');
+    expect(config.id).toEqual('my-config-1-id');
+    expect(config.parameters).toBeDefined();
+    expect(config.parameters?.path).toBeDefined();
+    expect(config.parameters?.path).toEqual('/home/user/tmp');
+  });
+
+  it('deleteConfiguration', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('configuration-0.json'));
+    const response = await client.deleteConfiguration("my-source-type-1-id", "my-config-1-id");
+    const config = response.getModel()!;
+
+    expect(config.name).toEqual('My configuration 1');
+    expect(config.description).toEqual('My configuration 1 description');
+    expect(config.id).toEqual('my-config-1-id');
+    expect(config.parameters).toBeDefined();
+    expect(config.parameters?.path).toBeDefined();
+    expect(config.parameters?.path).toEqual('/home/user/tmp');
+  });
+
 });

--- a/tsp-typescript-client/src/protocol/tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.ts
@@ -20,6 +20,8 @@ import { OutputStyleModel } from "../models/styles";
 import { HealthStatus } from "../models/health";
 import { MarkerSet } from "../models/markerset";
 import { DataTreeEntry } from "../models/data-tree";
+import { ConfigurationSourceType } from "../models/configuration-source";
+import { Configuration } from "../models/configuration";
 
 export {
     /** @deprecated */ HttpTspClient as TspClient,
@@ -294,4 +296,57 @@ export interface ITspClient {
      * @returns The Health Status
      */
     checkHealth(): Promise<TspClientResponse<HealthStatus>>;
+
+    /**
+     * Fetch all configuration source types
+     * @returns Generic response with the model
+     */
+    fetchConfigurationSourceTypes(): Promise<TspClientResponse<ConfigurationSourceType[]>>;
+
+    /**
+     * Fetch configuration source type for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    fetchConfigurationSourceType(typeId: string): Promise<TspClientResponse<ConfigurationSourceType>>;
+
+    /**
+     * Fetch all configurations for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    fetchConfigurations(typeId: string): Promise<TspClientResponse<Configuration[]>>;
+
+    /**
+     * Fetch a configuration by ID for a given type ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    fetchConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>>;
+
+    /**
+     * Create a configuration for a given type ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    createConfiguration(typeId: string, parameters: Query): Promise<TspClientResponse<Configuration>>;
+
+    /**
+     * Update a configuration for a given type ID, config ID and parameters
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @param parameters Query object
+     * @returns Generic response with the model
+     */
+    updateConfiguration(typeId: string, configId: string, parameters: Query): Promise<TspClientResponse<Configuration>>;
+
+    /**
+     * Delete a configuration for a given type ID and config ID
+     * @param typeId the ID of the configuration source type
+     * @param configId the ID of the configuration
+     * @returns Generic response with the model
+     */
+    deleteConfiguration(typeId: string, configId: string): Promise<TspClientResponse<Configuration>>;
 }


### PR DESCRIPTION
This adds APIs to the tsp-client to use the end-points newly defined in TSP:
- https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/93
- https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/92

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>