### PR TITLE
Update model for configuration source type parameters

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
@@ -3,7 +3,7 @@
 		"id": "my-source-type-1-id",
 		"name": "My configuration source 1",
 		"description": "My configuration source 1 description",
-		"configParamDescriptors": [ 
+		"parameterDescriptors": [
 			{
 				"keyName": "path",
 				"description": "path description",

--- a/tsp-typescript-client/src/models/configuration-source.ts
+++ b/tsp-typescript-client/src/models/configuration-source.ts
@@ -22,13 +22,13 @@ export interface ConfigurationSourceType {
      * A list of query parameter keys to be passed when creating
      * configuration instance of this type
      */
-    configParamDescriptors: ConfigParamDescriptor[];
+    parameterDescriptors: ConfigurationParameterDescriptor[];
 }
 
 /**
  * Model of a configuration parameter descriptor
  */
-export interface ConfigParamDescriptor {
+export interface ConfigurationParameterDescriptor {
     /**
      * The unique name of the key
      */

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -394,17 +394,18 @@ describe('HttpTspClient Deserialization', () => {
     expect(sourceTypes[0].name).toEqual('My configuration source 1');
     expect(sourceTypes[0].description).toEqual('My configuration source 1 description');
     expect(sourceTypes[0].id).toEqual('my-source-type-1-id');
-    expect(sourceTypes[0].configParamDescriptors).toHaveLength(2);
+    console.log(sourceTypes[0]);
+    expect(sourceTypes[0].parameterDescriptors).toHaveLength(2);
 
-    expect(sourceTypes[0].configParamDescriptors[0].keyName).toEqual('path');
-    expect(sourceTypes[0].configParamDescriptors[0].description).toEqual('path description');
-    expect(sourceTypes[0].configParamDescriptors[0].dataType).toEqual('STRING');
-    expect(sourceTypes[0].configParamDescriptors[0].isRequired).toBeTruthy();
+    expect(sourceTypes[0].parameterDescriptors[0].keyName).toEqual('path');
+    expect(sourceTypes[0].parameterDescriptors[0].description).toEqual('path description');
+    expect(sourceTypes[0].parameterDescriptors[0].dataType).toEqual('STRING');
+    expect(sourceTypes[0].parameterDescriptors[0].isRequired).toBeTruthy();
 
-    expect(sourceTypes[0].configParamDescriptors[1].keyName).toEqual('test1');
-    expect(sourceTypes[0].configParamDescriptors[1].description).toBeUndefined();
-    expect(sourceTypes[0].configParamDescriptors[1].dataType).toBeUndefined();
-    expect(sourceTypes[0].configParamDescriptors[1].isRequired).toBeUndefined();
+    expect(sourceTypes[0].parameterDescriptors[1].keyName).toEqual('test1');
+    expect(sourceTypes[0].parameterDescriptors[1].description).toBeUndefined();
+    expect(sourceTypes[0].parameterDescriptors[1].dataType).toBeUndefined();
+    expect(sourceTypes[0].parameterDescriptors[1].isRequired).toBeUndefined();
   });
 
   it('configurations', async () => {


### PR DESCRIPTION
This commit changes the name of the configuration parameter property of the configuration source type model so that it matches the model returned by the trace server and as declared in the TSP specifications.