### PR TITLE
Add 3PP license check as part of PR CI

### DIFF
--- a/.github/workflows/license-check-workflow.yml
+++ b/.github/workflows/license-check-workflow.yml
@@ -1,0 +1,52 @@
+name: 3PP License Check
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 4 * * *' # Runs every day at 4am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+
+jobs:
+
+  License-check:
+    name: 3PP License Check using dash-licenses
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [18]
+        java: [11]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Use Java ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
+      - name: Run dash-licenses
+        shell: bash
+        run: |
+          yarn --frozen-lockfile --ignore-scripts
+          yarn license:check
+        env:
+          DASH_TOKEN: ${{ secrets.DASH_LICENSES_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 coverage
 lib
 node_modules
+license-check-summary.txt*

--- a/configs/license-check-config.json
+++ b/configs/license-check-config.json
@@ -1,0 +1,8 @@
+{
+    "project": "ecd.cdt-cloud",
+    "review": false,
+    "inputFile": "yarn.lock",
+    "batch": 50,
+    "timeout": 200,
+    "summary": "license-check-summary.txt"
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "src"
   ],
   "devDependencies": {
+    "@eclipse-dash/nodejs-wrapper": "^0.0.1",
     "lerna": "^7.0.0",
     "typescript": "^5.2.2"
   },
@@ -36,6 +37,8 @@
     "clean": "lerna run clean",
     "test": "lerna run test --",
     "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --no-git-tag-version --no-push",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes"
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary minor --preid=next.$(date -u '+%Y%m%d%H%M%S').$(git rev-parse --short HEAD) --dist-tag=next --no-git-tag-version --no-push --yes",
+    "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
+    "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,6 +314,11 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@eclipse-dash/nodejs-wrapper@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-dash/nodejs-wrapper/-/nodejs-wrapper-0.0.1.tgz#f2629671cf090a84c4d69a8fec42f198e583d103"
+  integrity sha512-Rkk8O8hEVi/+LC/co7ly1zGLVwCNJG3yPbalsz1FHAqk6WZyEaWNf29EX6jz4vTfR5wpv2xAfF2yokKuStiOdA==
+
 "@hutson/parse-repository-url@^3.0.0":
   version "3.0.2"
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"


### PR DESCRIPTION
Depends on [dash-licenses nodejs-wrapper](https://github.com/eclipse-dash/nodejs-wrapper) being released on npm. ([ongoing](https://github.com/eclipse-dash/nodejs-wrapper/pull/2))

However, I went ahead and published a v0.0.1 so we can start using it immediately - the plan is to catch-up with the PR above and a small subsequent one that will create the GitHub release for this version.

For now the CI job it will be only informational, letting the committers know that some 3PPs look suspicious. Any committer can then run the dash-licenses wrapper locally to automatically create the required IP ticket(s) - see commit message for more details.

Closes #93