### PR TITLE
Move rimraf dependency from prod to dev

### DIFF
--- a/tsp-typescript-client/package.json
+++ b/tsp-typescript-client/package.json
@@ -15,12 +15,12 @@
     "@types/node": "^11.13.8",
     "@types/node-fetch": "^2.3.3",
     "jest": "^27.1.0",
+    "rimraf": "latest",
     "typescript": "^5.2.2"
   },
   "dependencies": {
     "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
-    "node-fetch": "^2.5.0",
-    "rimraf": "latest"
+    "node-fetch": "^2.5.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",


### PR DESCRIPTION
rimraf is used as a development dependency but was pulled as a production dependency. This had the side-effect of making its own production dependencies mandatory for other projects using it.