### PR TITLE
Release 0.4.0

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.0.0
+tag: v0.4.0
 
 commitInclude:
   parentOfMergeCommit: true

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "7.3.0",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/tsp-typescript-client/package.json
+++ b/tsp-typescript-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsp-typescript-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Trace Server Protocol client written in TypeScript",
   "author": "Ericsson and others",
   "license": "MIT",

--- a/tsp-typescript-client/package.json
+++ b/tsp-typescript-client/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client"
   },
   "bugs": {
-      "url": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client/issues"
+    "url": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client/issues"
   },
   "homepage": "https://github.com/eclipse-cdt-cloud/tsp-typescript-client"
-  }
+}


### PR DESCRIPTION
Release/publish a new `latest` version of `tsp-typescript-client`, using the newly added CI infrastructure. 