### PR TITLE
[ci] Add missing workflow trigger: 'release'

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - master
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This was missed in the previous infrastructure PR, and is necessary for the "publish-latest" job to run.