### PR TITLE
WIP: support end-point to query entry context

### DIFF
--- a/tsp-typescript-client/src/models/query/query-helper.ts
+++ b/tsp-typescript-client/src/models/query/query-helper.ts
@@ -59,6 +59,14 @@ export class QueryHelper {
         return new Query({ ...timeObj, ...additionalProperties });
     }
 
+    public static selectionQuery(items: number[], additionalProperties?: { [key: string]: any }): Query {
+        const selectionObj = {
+            [this.REQUESTED_ITEMS_KEY]: items
+        };
+
+        return new Query({ ...selectionObj, ...additionalProperties });
+    }
+
     /**
      * Build a simple time query with selected items
      * @param requestedTimes Array of requested times

--- a/tsp-typescript-client/src/protocol/http-tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/http-tsp-client.ts
@@ -302,6 +302,28 @@ export class HttpTspClient implements ITspClient {
     }
 
     /**
+     * Fetch Time Graph tree, Model extends TimeGraphEntry
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with entries of type TimeGraphEntry
+     */
+    public async fetchTimeGraphTreeContext(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: unknown }>>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/timeGraph/" +
+            outputID +
+            "/tree:context";
+        return RestClient.post(url, parameters);    
+    }
+
+    /**
      * Fetch Time Graph states. Model extends TimeGraphModel
      * @param expUUID Experiment UUID
      * @param outputID Output ID

--- a/tsp-typescript-client/src/protocol/tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.ts
@@ -180,6 +180,19 @@ export interface ITspClient {
     ): Promise<TspClientResponse<GenericResponse<EntryModel<TimeGraphEntry>>>>;
 
     /**
+     * Fetch Time Graph tree, Model extends TimeGraphEntry
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Time graph entry response with entries of type TimeGraphEntry
+     */
+    fetchTimeGraphTreeContext(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<{ [key: string]: unknown }>>>;
+
+    /**
      * Fetch Time Graph states. Model extends TimeGraphModel
      * @param expUUID Experiment UUID
      * @param outputID Output ID


### PR DESCRIPTION
e.g. can be used to retrieve thread context (hostId/threadId/threadName) to be passed to critical path analysis.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>