### PR TITLE
Add parameter "properties" in model "Trace"

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/create-experiment-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/create-experiment-0.json
@@ -13,6 +13,11 @@
 			"nbEvents": 999999,
 			"start": 1234567890123456789,
 			"end": 9876543210987654321,
+			"properties":
+			{
+				"hostname": "qemu1",
+				"clock_offset": "1450192743562703624"
+			},
 			"indexingStatus": "COMPLETED"
 		}
 	]

--- a/tsp-typescript-client/fixtures/tsp-client/delete-experiment-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/delete-experiment-0.json
@@ -13,6 +13,11 @@
 			"nbEvents": 0,
 			"start": 0,
 			"end": 0,
+			"properties":
+			{
+				"hostname": "qemu1",
+				"clock_offset": "1450192743562703624"
+			},
 			"indexingStatus": "CLOSED"
 		}
 	]

--- a/tsp-typescript-client/fixtures/tsp-client/delete-trace-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/delete-trace-0.json
@@ -5,5 +5,10 @@
 	"nbEvents": 0,
 	"start": 0,
 	"end": 0,
+	"properties":
+	{
+		"hostname": "qemu1",
+		"clock_offset": "1450192743562703624"
+	},
 	"indexingStatus": "CLOSED"
 }

--- a/tsp-typescript-client/fixtures/tsp-client/open-trace-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/open-trace-0.json
@@ -5,5 +5,10 @@
 	"nbEvents": 0,
 	"start": 0,
 	"end": 0,
+	"properties":
+	{
+		"hostname": "qemu1",
+		"clock_offset": "1450192743562703624"
+	},
 	"indexingStatus": "CLOSED"
 }

--- a/tsp-typescript-client/src/models/trace.ts
+++ b/tsp-typescript-client/src/models/trace.ts
@@ -4,6 +4,7 @@ export const Trace = createNormalizer<Trace>({
     end: BigInt,
     nbEvents: assertNumber,
     start: BigInt,
+    properties: undefined,
 });
 
 /**
@@ -39,6 +40,11 @@ export interface Trace {
      * Current number of events
      */
     nbEvents: number;
+
+    /**
+     * Trace's properties
+     */
+    properties: Record<string, any>;
 
     /**
      * Indicate if the indexing of the trace is completed or still running.

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -116,6 +116,7 @@ describe('HttpTspClient Deserialization', () => {
     expect(typeof trace.end).toEqual('bigint');
     expect(typeof trace.start).toEqual('bigint');
     expect(typeof trace.nbEvents).toEqual('number');
+    expect(typeof trace.properties).toEqual('object');
   });
 
   it('experimentOutputs', async () => {
@@ -398,6 +399,7 @@ describe('HttpTspClient Deserialization', () => {
     expect(typeof trace.end).toEqual('bigint');
     expect(typeof trace.nbEvents).toEqual('number');
     expect(typeof trace.start).toEqual('bigint');
+    expect(typeof trace.properties).toEqual('object');
   });
 
   it('configurationSourceTypes', async () => {


### PR DESCRIPTION
Add the parameter "properties" introduced by commit 499408e3979cab403a5d58 in the server (incubator).

Link to the PR for the commit: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/79