### PR TITLE
Add custom analysis related APIs

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
@@ -22,5 +22,21 @@
 		"name": "Output name",
 		"description": "Output description",
 		"type": "TIME_GRAPH"
+	},
+	{
+		"id": "timegraph.output.id2",
+		"name": "Output name (Config)",
+		"description": "Output description (Config)",
+		"type": "TIME_GRAPH",
+		"parentId": "timegraph.output.id",
+		"configuration" : {
+			"id": "my-config-1-id",
+			"name": "My configuration 1",
+			"description": "My configuration 1 description",
+			"sourceTypeId": "my-source-type-1-id",
+			"parameters": {
+				"path": "/home/user/tmp"
+			}
+		}
 	}
 ]

--- a/tsp-typescript-client/fixtures/tsp-client/output-configuration-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/output-configuration-0.json
@@ -1,0 +1,25 @@
+{
+  "parentId": "org.eclipse.tracecompass.incubator.inandout.core.analysis.inAndOutDataProviderFactory",
+  "id": "org.eclipse.tracecompass.incubator.inandout.analysis85eec6d6-bea0-3680-84b6-f1a200e852d1",
+  "name": "InAndOut Analysis (My new InAndOut)",
+  "description": "Custom InAndOut analysis configured by \"My new InAndOut\"",
+  "type": "NONE",
+  "configuration": {
+    "id": "85eec6d6-bea0-3680-84b6-f1a200e852d1",
+    "name": "My new InAndOut",
+    "description": "My special configuration",
+    "sourceTypeId": "org.eclipse.tracecompass.incubator.internal.inandout.core.config",
+    "parameters": {
+      "specifiers": [
+        {
+          "label": "latency",
+          "inRegex": "(\\S*)_entry",
+          "outRegex": "(\\S*)_exit",
+          "contextInRegex": "(\\S*)_entry",
+          "contextOutRegex": "(\\S*)_exit",
+          "classifier": "CPU"
+        }
+      ]
+    }
+  }
+}

--- a/tsp-typescript-client/src/models/configuration.ts
+++ b/tsp-typescript-client/src/models/configuration.ts
@@ -1,3 +1,8 @@
+import { createNormalizer } from "../protocol/serialization";
+
+export const Configuration = createNormalizer<Configuration>({
+    parameters: undefined
+});
 
 /**
  * Model of a configuration instance

--- a/tsp-typescript-client/src/models/output-descriptor.ts
+++ b/tsp-typescript-client/src/models/output-descriptor.ts
@@ -9,6 +9,34 @@ export const OutputDescriptor = createNormalizer<OutputDescriptor>({
 });
 
 /**
+ * Provider type 
+ */
+export enum ProviderType {
+    /**
+     * A provider for a table data structure implemented as virtual table.
+     */
+    TABLE = 'TABLE',
+    /**
+     * A provider for a tree, whose entries have XY series. The x-series is time.
+     */
+    TREE_TIME_XY = 'TREE_TIME_XY',
+    /**
+     * A provider for a Time Graph model, which has entries with a start and end
+     * time, each entry has a series of states, arrows link from one series to
+     * another
+     */
+    TIME_GRAPH = 'TIME_GRAPH',
+    /**
+     * A provider for a data tree, which has entries (rows) and columns.
+     */
+    DATA_TREE = 'DATA_TREE',
+    /**
+     * A provider with no data. Can be used for grouping purposes and/or as data provider configurator.
+     */
+    NONE = 'NONE'
+}
+
+/**
  * Descriptor of a specific output provider
  */
 export interface OutputDescriptor {
@@ -35,6 +63,8 @@ export interface OutputDescriptor {
     /**
      * Type of data returned by this output.
      * Serve as a hint to determine what kind of view should be use for this output (ex. XY, Time Graph, Table, etc..)
+     * 
+     * See {@link ProviderType} for supported strings.
      */
     type: string;
 

--- a/tsp-typescript-client/src/models/output-descriptor.ts
+++ b/tsp-typescript-client/src/models/output-descriptor.ts
@@ -1,15 +1,22 @@
 import { createNormalizer } from '../protocol/serialization';
+import { Configuration } from './configuration';
 
 export const OutputDescriptor = createNormalizer<OutputDescriptor>({
     end: BigInt,
     queryParameters: undefined,
     start: BigInt,
+    configuration: Configuration
 });
 
 /**
  * Descriptor of a specific output provider
  */
 export interface OutputDescriptor {
+    /**
+     * Output provider's parent ID
+     */
+    parentId?: string;
+
     /**
      * Output provider's ID
      */
@@ -56,4 +63,9 @@ export interface OutputDescriptor {
      * List of compatible outputs that can be used in the same view (ex. as overlay)
      */
     compatibleProviders?: string[];
+
+    /**
+     * Configuration used to create this data provider.
+     */
+    configuration?: Configuration;
 }

--- a/tsp-typescript-client/src/models/query/query-helper.test.ts
+++ b/tsp-typescript-client/src/models/query/query-helper.test.ts
@@ -1,5 +1,5 @@
 import { QueryHelper } from './query-helper';
-import { Query } from './query';
+import { ConfigurationQuery, OutputConfigurationQuery, Query } from './query';
 
 describe('Query helper tests', () => {
   it('Should build a simple query', () => {
@@ -104,5 +104,51 @@ describe('Query helper tests', () => {
     const test = QueryHelper.splitRangeIntoEqualParts(start, end, parts);
 
     expect(test).toEqual(array);
+  });
+
+  it('Should create a configuration query', () => {
+    const param = {
+      cpu: 0,
+      thread: "myThread"
+    };
+
+    const test = QueryHelper.configurationQuery(
+      'My Config',
+      'My special configuration', 
+      param);
+
+    const query = new ConfigurationQuery('My Config',
+      'My special configuration',
+      param);
+    
+    expect(test).toEqual(query);
+  });
+
+  it('Should create a output configuration query', () => {
+    const param = {
+      specifiers: [
+        {
+         label: 'latency',
+         inRegex: '(\\S*)_entry',
+          outRegex: '(\\S*)_exit',
+         contextInRegex: '(\\S*)_entry',
+         contextOutRegex: '(\\S*)_exit',
+          classifier: 'CPU'
+        }
+      ]
+    };
+
+  const test = QueryHelper.outputConfigurationQuery(
+    'My new InAndOut',
+    'org.eclipse.tracecompass.incubator.internal.inandout.core.config',
+    'My special configuration', 
+    param);
+
+    const query = new OutputConfigurationQuery('My new InAndOut',
+      'org.eclipse.tracecompass.incubator.internal.inandout.core.config',
+      'My special configuration', 
+      param);
+
+    expect(test).toEqual(query);
   });
 });

--- a/tsp-typescript-client/src/models/query/query-helper.ts
+++ b/tsp-typescript-client/src/models/query/query-helper.ts
@@ -1,4 +1,4 @@
-import { Query } from './query';
+import { ConfigurationQuery, OutputConfigurationQuery, Query } from './query';
 
 /**
  * Helper class to create query object
@@ -161,6 +161,27 @@ export class QueryHelper {
         };
 
         return new Query({ ...tableObj, ...additionalProperties });
+    }
+
+    /**
+     * Build a configuration query
+     * @param name the name of the configuration
+     * @param description the optional description of the configuration
+     * @param parameters the custom parameters
+     */
+    public static configurationQuery(name: string, description: string | undefined, parameters: { [key: string]: any }) {
+        return new ConfigurationQuery(name, description, parameters);
+    }
+
+    /**
+     * Build a output configuration query
+     * @param name the name of the configuration
+     * @param description the optional description of the configuration
+     * @param typeId the configuration type ID
+     * @param parameters the custom parameters
+     */
+    public static outputConfigurationQuery(name: string, description: string | undefined, typeId: string, parameters: { [key: string]: any }) {
+        return new OutputConfigurationQuery(name, description, typeId, parameters);
     }
 
     /**

--- a/tsp-typescript-client/src/models/query/query.ts
+++ b/tsp-typescript-client/src/models/query/query.ts
@@ -19,3 +19,47 @@ export class Query {
         this.parameters = parameters;
     }
 }
+export class ConfigurationQuery extends Query {
+    /**
+     * Name of the configuration
+     */
+    // @ts-expect-error TS doesn't like unused private fields.
+    private name: string;
+
+    /**
+     * The optional description of configuration
+     */
+    // @ts-expect-error TS doesn't like unused private fields.
+    private description?: string;
+
+    /**
+     * Constructor
+     * @param name Name of the configuration
+     * @param parameters Object used to send parameters to the server
+     * @param description Optional description of the configuraiton
+     */
+    constructor(name: string, descripion: string | undefined, parameters: Object) {
+        super(parameters);
+        this.name = name;
+        this.description = descripion;
+    }
+}
+export class OutputConfigurationQuery extends ConfigurationQuery {
+    /**
+     * The configuration source type ID
+     */
+    // @ts-expect-error TS doesn't like unused private fields.
+    private typeId: string;
+
+    /**
+     * Constructor
+     * @param name Name of the configuration
+     * @param description Optional description of the configuraiton
+     * @param typeId The ID of the configuration source type
+     * @param parameters Object used to send parameters to the server
+     */
+    constructor(name: string, description: string | undefined,  typeId: string, parameters: Object) {
+        super(name, description, parameters);
+        this.typeId = typeId;
+    }
+}

--- a/tsp-typescript-client/src/protocol/http-tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/http-tsp-client.ts
@@ -11,7 +11,7 @@ import { HealthStatus } from "../models/health";
 import { Identifier } from "../models/identifier";
 import { MarkerSet } from "../models/markerset";
 import { OutputDescriptor } from "../models/output-descriptor";
-import { Query } from "../models/query/query";
+import { ConfigurationQuery, OutputConfigurationQuery, Query } from "../models/query/query";
 import { GenericResponse } from "../models/response/responses";
 import { OutputStyleModel } from "../models/styles";
 import { ColumnHeaderEntry, TableModel } from "../models/table";
@@ -512,6 +512,92 @@ export class HttpTspClient implements ITspClient {
     }
 
     /**
+     * Fetch all configuration source types for a given experiment and output
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @returns Generic response with the model
+     */
+    public async fetchOutputConfigurationTypes(
+        expUUID: string,
+        outputID: string
+    ): Promise<TspClientResponse<ConfigurationSourceType[]>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/" +
+            outputID +
+            "/configTypes";
+        return RestClient.get(url);
+    }
+
+    /**
+     * Fetch a single configuration source type for a given experiment, output and type
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param typeID the ID of the configuration source type
+     * @returns Generic response with the model
+     */
+    public async fetchOutputConfigurationType(
+        expUUID: string,
+        outputID: string,
+        typeID: string
+    ): Promise<TspClientResponse<ConfigurationSourceType>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/" +
+            outputID +
+            "/configTypes/" +
+            typeID;
+        return RestClient.get(url);
+    }
+
+    /**
+     * Create a derived output for a given experiment, output and parameters
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters OutputConfigurationQuery object
+     * @returns Generic response with the model
+     */
+    public async createDerivedOutput(
+        expUUID: string,
+        outputID: string,
+        parameters: OutputConfigurationQuery): Promise<TspClientResponse<OutputDescriptor>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/" +
+            outputID;
+        return RestClient.post(url, parameters, OutputDescriptor);
+    }
+
+    /**
+     * Delete a derived output (and its configuration) for a given experiment,
+     * output and derived output
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param derivedOutputID the ID of the derived output
+     * @returns Generic response with the model
+     */
+    public async deleteDerivedOutput(
+        expUUID: string,
+        outputID: string,
+        derivedOutputID: string): Promise<TspClientResponse<OutputDescriptor>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/" +
+            outputID +
+            "/" +
+            derivedOutputID;
+        return RestClient.delete(url, undefined, OutputDescriptor);
+        }
+
+    /**
      * Check the health status of the server
      * @returns The Health Status
      */
@@ -572,10 +658,10 @@ export class HttpTspClient implements ITspClient {
     /**
      * Create a configuration for a given type ID and parameters
      * @param typeId the ID of the configuration source type
-     * @param parameters Query object
+     * @param parameters ConfigurationQuery object
      * @returns Generic response with the model
      */
-    createConfiguration(typeId: string, parameters: Query): Promise<TspClientResponse<Configuration>> {
+    createConfiguration(typeId: string, parameters: ConfigurationQuery): Promise<TspClientResponse<Configuration>> {
         const url = this.baseUrl + "/config/types/" + typeId;
         return RestClient.post(url, parameters);
     }
@@ -584,10 +670,10 @@ export class HttpTspClient implements ITspClient {
      * Update a configuration for a given type ID, config ID and parameters
      * @param typeId the ID of the configuration source type
      * @param configId the ID of the configuration
-     * @param parameters Query object
+     * @param parameters ConfigurationQuery object
      * @returns Generic response with the model
      */
-    updateConfiguration(typeId: string, configId: string, parameters: Query): Promise<TspClientResponse<Configuration>> {
+    updateConfiguration(typeId: string, configId: string, parameters: ConfigurationQuery): Promise<TspClientResponse<Configuration>> {
         const url = this.baseUrl + "/config/types/" + typeId + "/configs/" + configId;
         return RestClient.put(url, parameters);
     }

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -124,7 +124,7 @@ describe('HttpTspClient Deserialization', () => {
     const response = await client.experimentOutputs('not-relevant');
     const outputs = response.getModel()!;
 
-    expect(outputs).toHaveLength(4);
+    expect(outputs).toHaveLength(5);
   });
 
   it('fetchAnnotationsCategories', async () => {

--- a/tsp-typescript-client/src/protocol/tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.ts
@@ -1,4 +1,4 @@
-import { Query } from "../models/query/query";
+import { ConfigurationQuery, OutputConfigurationQuery, Query } from "../models/query/query";
 import { GenericResponse } from "../models/response/responses";
 import { XyEntry, XYModel } from "../models/xy";
 import {
@@ -293,6 +293,55 @@ export interface ITspClient {
     ): Promise<TspClientResponse<GenericResponse<OutputStyleModel>>>;
 
     /**
+     * Fetch all configuration source types for a given experiment and output
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @returns a list of configuration source types
+     */
+    fetchOutputConfigurationTypes(
+        expUUID: string,
+        outputID: string
+    ): Promise<TspClientResponse<ConfigurationSourceType[]>>;
+
+    /**
+     * Fetch a single configuration source type for a given experiment, output and type
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param typeID the ID of the configuration source type
+     * @returns the configuration source type
+     */
+    fetchOutputConfigurationType(
+        expUUID: string,
+        outputID: string,
+        typeID: string
+    ): Promise<TspClientResponse<ConfigurationSourceType>>;
+
+    /**
+     * Create a derived output for a given experiment, output and parameters
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters OutputConfigurationQuery object
+     * @returns the output descriptor of the derived output
+     */
+    createDerivedOutput(
+        expUUID: string,
+        outputID: string,
+        parameters: OutputConfigurationQuery): Promise<TspClientResponse<OutputDescriptor>>;
+
+    /**
+     * Delete a derived output (and its configuration) for a given experiment,
+     * output and derived output
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param derivedOutputID the ID of the derived output
+     * @returns the output descriptor of the deleted derived output
+     */
+    deleteDerivedOutput(
+        expUUID: string,
+        outputID: string,
+        derivedOutputID: string): Promise<TspClientResponse<OutputDescriptor>>;
+
+    /**
      * Check the health status of the server
      * @returns The Health Status
      */
@@ -338,7 +387,7 @@ export interface ITspClient {
      * @param parameters Query object
      * @returns Generic response with the model
      */
-    createConfiguration(typeId: string, parameters: Query): Promise<TspClientResponse<Configuration>>;
+    createConfiguration(typeId: string, parameters: ConfigurationQuery): Promise<TspClientResponse<Configuration>>;
 
     /**
      * Update a configuration for a given type ID, config ID and parameters
@@ -347,7 +396,7 @@ export interface ITspClient {
      * @param parameters Query object
      * @returns Generic response with the model
      */
-    updateConfiguration(typeId: string, configId: string, parameters: Query): Promise<TspClientResponse<Configuration>>;
+    updateConfiguration(typeId: string, configId: string, parameters: ConfigurationQuery): Promise<TspClientResponse<Configuration>>;
 
     /**
      * Delete a configuration for a given type ID and config ID


### PR DESCRIPTION
- Support parentId and creation configuration in output descriptors
- Add ProviderType enum for the type in OutputDescriptors
- Add APIs to support configurable output (data provider)
  - Add ConfigurationQuery and OutputConfigurationQuery
  - Add utility methods in query-helper.ts to create such query instances
  - Add configuration service per output (data provider)
    This addition enables clients to create derived data providers from
    an existing data provider.
  - Add unit tests

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
