### PR TITLE
Align OutputConfigurationQuery/Configuration for sourceTypeId

### DIFF
--- a/tsp-typescript-client/src/models/query/query.ts
+++ b/tsp-typescript-client/src/models/query/query.ts
@@ -49,17 +49,17 @@ export class OutputConfigurationQuery extends ConfigurationQuery {
      * The configuration source type ID
      */
     // @ts-expect-error TS doesn't like unused private fields.
-    private typeId: string;
+    private sourceTypeId: string;
 
     /**
      * Constructor
      * @param name Name of the configuration
      * @param description Optional description of the configuraiton
-     * @param typeId The ID of the configuration source type
+     * @param sourceTypeId The ID of the configuration source type
      * @param parameters Object used to send parameters to the server
      */
-    constructor(name: string, description: string | undefined,  typeId: string, parameters: Object) {
+    constructor(name: string, description: string | undefined, sourceTypeId: string, parameters: Object) {
         super(name, description, parameters);
-        this.typeId = typeId;
+        this.sourceTypeId = sourceTypeId;
     }
 }


### PR DESCRIPTION
In the OutputConfigurationQuery the configuration source type id was called typeId and it creates a Configuration object where the same field is called sourceTypeId for the same field. When serializing the Configuration in the derived DataProviderDescriptor over TSP the field is called sourceTypeId and this is not consistent. The returned Configuration should have the exact field names that are used when creating the data provider and the respective configuration.

The Configuration is already API while OutputConfigurationQuery is not, and it's better to change the name there.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>