### PR TITLE
Add optional OutputCapabilities to the output descriptor

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
@@ -24,11 +24,21 @@
 		"type": "TIME_GRAPH"
 	},
 	{
+		"id": "timegraph.output.id1",
+		"name": "Output name (Config)",
+		"description": "Output description (Config)",
+		"type": "TIME_GRAPH",
+		"capabilities": {
+			"canCreate": true,
+			"canDelete": false
+		}
+	},
+	{
 		"id": "timegraph.output.id2",
 		"name": "Output name (Config)",
 		"description": "Output description (Config)",
 		"type": "TIME_GRAPH",
-		"parentId": "timegraph.output.id",
+		"parentId": "timegraph.output.id1",
 		"configuration" : {
 			"id": "my-config-1-id",
 			"name": "My configuration 1",
@@ -37,6 +47,10 @@
 			"parameters": {
 				"path": "/home/user/tmp"
 			}
+		},
+		"capabilities": {
+			"canCreate": false,
+			"canDelete": true
 		}
 	}
 ]

--- a/tsp-typescript-client/src/models/output-capabilities.ts
+++ b/tsp-typescript-client/src/models/output-capabilities.ts
@@ -1,0 +1,19 @@
+/**
+ * Capabilities class indicating capabilities of a data provider, such as
+ * "canCreate" and "canDelete" capability.
+ * 
+ * "canCreate" indicates that a given data provider can create a derived data
+ * provider. "canDelete" indicates that a given data provider can be deleted.
+ * 
+ */
+export class OutputCapabilities {
+    /**
+     * Whether the data provider can create derived data providers. 'false' if absent. 
+     */
+    canCreate?: boolean;
+
+    /**
+     * Whether the data provider can be deleted. 'false' if absent.
+     */
+    canDelete?: boolean;
+}

--- a/tsp-typescript-client/src/models/output-descriptor.ts
+++ b/tsp-typescript-client/src/models/output-descriptor.ts
@@ -1,5 +1,6 @@
 import { createNormalizer } from '../protocol/serialization';
 import { Configuration } from './configuration';
+import { OutputCapabilities } from './output-capabilities';
 
 export const OutputDescriptor = createNormalizer<OutputDescriptor>({
     end: BigInt,
@@ -98,4 +99,9 @@ export interface OutputDescriptor {
      * Configuration used to create this data provider.
      */
     configuration?: Configuration;
+
+    /**
+     * The output (data provider) capabilities instance. If absent all capabilities are false.
+     */
+    capabilities?: OutputCapabilities;
 }

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -125,8 +125,21 @@ describe('HttpTspClient Deserialization', () => {
     httpRequestMock.mockReturnValueOnce(fixtures.asResponse('experiment-outputs-0.json'));
     const response = await client.experimentOutputs('not-relevant');
     const outputs = response.getModel()!;
+    expect(outputs).toHaveLength(6);
 
-    expect(outputs).toHaveLength(5);
+    let output = outputs.find((item) => item.id === 'timegraph.output.id1');
+    expect(output).toBeDefined();
+    expect(output?.capabilities).toBeDefined();
+    expect(output?.capabilities?.canCreate).toBeTruthy();
+    expect(output?.capabilities?.canDelete).toBeFalsy();
+    expect(output?.configuration).toBeUndefined();
+
+    output = outputs.find((item) => item.id === 'timegraph.output.id2');
+    expect(output).toBeDefined();
+    expect(output?.capabilities).toBeDefined();
+    expect(output?.capabilities?.canCreate).toBeFalsy();
+    expect(output?.capabilities?.canDelete).toBeTruthy();
+    expect(output?.configuration).toBeDefined();
   });
 
   it('fetchAnnotationsCategories', async () => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

OutputCapabilities indicate capabilities of an output, such as "canCreate" and "canDelete". "canCreate" indicates that a given output can create a derived outputs. "canDelete" indicates that a given output can be deleted.

See also ADR: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

### How to test

Run the unit tests (`yarn tests`)

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>