### PR TITLE
[CI][workflows] Use node 20 by default, align GitHub workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,14 +17,14 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and test
+    name: Build and test (${{ matrix.os }}, node-${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node-version: [18,20,22]
 
     steps:
       - name: Checkout
@@ -32,10 +32,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Use Node.js ${{ matrix.node }}
+      - name: Use Node.js ${{ matrix.node-node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Build
         shell: bash
@@ -55,13 +55,17 @@ jobs:
     name: Publish 'next' package to npm
     needs: build-and-test
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && github.repository == 'eclipse-cdt-cloud/tsp-typescript-client'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20]
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: yarn --frozen-lockfile
       - name: Publish 'next'
@@ -81,12 +85,17 @@ jobs:
     name: Publish 'latest' package to npm
     needs: build-and-test
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'eclipse-cdt-cloud/tsp-typescript-client'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [20]
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: yarn --frozen-lockfile
       - name: Publish 'latest'

--- a/.github/workflows/license-check-workflow.yml
+++ b/.github/workflows/license-check-workflow.yml
@@ -14,13 +14,13 @@ on:
 jobs:
 
   License-check:
-    name: 3PP License Check using dash-licenses
+    name: 3PP License Check using dash-licenses (${{ matrix.os }})
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [18]
+        node-version: [20]
         java: [11]
 
     runs-on: ${{ matrix.os }}
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Use Java ${{ matrix.java }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Prepare for node.js 18 EoL and our transition to using node 20 as default. 
- start using node 20 for jobs like linting, publishing and license check
- Add Node 20 and node 22 to the matrix for "build and test" job
- (for now) Keep node 18 as part of the "matrix" for "build and test job". We can remove it once officially EoL


### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Confirm CI still passes.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
