### PR TITLE
Add `autoExpandLevel` flag to EntryModel

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/fetch-data-tree-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-data-tree-0.json
@@ -1,5 +1,6 @@
 {
 	"model": {
+	  "autoExpandLevel": -1,
 	  "entries": [
 		{
 		  "id": 0,
@@ -113,4 +114,5 @@
 	},
 	"statusMessage": "Completed",
 	"status": "COMPLETED"
+
   }

--- a/tsp-typescript-client/fixtures/tsp-client/fetch-timegraph-tree-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-timegraph-tree-0.json
@@ -1,5 +1,6 @@
 {
 	"model": {
+		"autoExpandLevel": -1,
 		"entries": [
 			{
 				"id": 1234,

--- a/tsp-typescript-client/fixtures/tsp-client/fetch-xy-tree-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-xy-tree-0.json
@@ -1,5 +1,6 @@
 {
 	"model": {
+		"autoExpandLevel": -1,
 		"entries": [
 			{
 				"id": 111,

--- a/tsp-typescript-client/src/models/entry.ts
+++ b/tsp-typescript-client/src/models/entry.ts
@@ -7,7 +7,7 @@ export const Entry = createNormalizer<Entry>({
     style: {
         values: undefined,
     },
-    metadata: undefined,
+    metadata: undefined
 });
 
 /**
@@ -44,6 +44,7 @@ export interface Entry {
      * Metadata
      */
     metadata?: { [key: string]: any };
+
 }
 
 /**
@@ -68,6 +69,7 @@ export interface EntryHeader {
 export function EntryModel<T extends Entry>(normalizer: Normalizer<T>): Normalizer<EntryModel<T>> {
     return createNormalizer<EntryModel<any>>({
         entries: array(normalizer),
+        autoExpandLevel: assertNumber,
     });
 }
 
@@ -84,4 +86,16 @@ export interface EntryModel<T extends Entry> {
      * Array of entry
      */
     entries: T[];
+
+    /**
+     * Optional auto-expand level to be used for the input of the tree. If omitted value -1 is assumed.
+     * 
+     * Values:
+     * - -1 → All subtrees should be expanded
+     * - 0 → No auto-expand
+     * - 1 → Top-level elements are expanded, but not their children
+     * - 2 → Top-level elements and their children are expanded, but not grand-children
+     */
+    autoExpandLevel?: number;
+
 }

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -303,6 +303,7 @@ describe('HttpTspClient Deserialization', () => {
     const genericResponse = response.getModel()!;
     const model = genericResponse.model;
 
+    expect(model.autoExpandLevel).toEqual(-1);
     expect(model.entries).toHaveLength(1);
     expect(model.headers).toHaveLength(0);
     for (const entry of model.entries) {
@@ -373,7 +374,8 @@ describe('HttpTspClient Deserialization', () => {
                                { name: 'Total', tooltip: '', },
                                { name: 'Min Time Range', tooltip: '', dataType: DataType.TIME_RANGE },
                                { name: 'Max Time Range', tooltip: '', dataType: DataType.TIME_RANGE }];
-
+    
+    expect(model.autoExpandLevel).toEqual(-1);
     expect(model.entries).toHaveLength(4);
     expect(model.headers).toHaveLength(9);
 
@@ -399,6 +401,7 @@ describe('HttpTspClient Deserialization', () => {
     const genericResponse = response.getModel()!;
     const model = genericResponse.model;
 
+    expect(model.autoExpandLevel).toEqual(-1);
     expect(model.entries).toHaveLength(1);
     expect(model.headers).toHaveLength(4);
     for (const entry of model.entries) {


### PR DESCRIPTION
### What it does

Adds `autoExpandLevel` flag to EntryModel.

Relates to:
https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/277
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/196

### How to test

Make sure this works with latest tracecompass-server.

### Follow-ups

The functionality for the flag, the ability for the front-end to correctly expand / collapse tree nodes based on the value of `autoExpandLevel`, needs to be implemented.

### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
