### PR TITLE
Support ErrorResponse for error cases in all specified messages

### DIFF
--- a/tsp-typescript-client/src/models/error-response.ts
+++ b/tsp-typescript-client/src/models/error-response.ts
@@ -1,0 +1,14 @@
+/**
+ * Model of an error response
+ */
+export interface ErrorResponse {
+    /**
+     * The short, human-readable description of the error.
+     */
+    title: string;
+
+    /**
+     * The optional human-readable explanation of the error with details helping the client to correct the error.
+     */
+    details?: string;
+}

--- a/tsp-typescript-client/src/models/experiment-error-response.ts
+++ b/tsp-typescript-client/src/models/experiment-error-response.ts
@@ -1,0 +1,12 @@
+import { ErrorResponse } from "./error-response";
+import { Experiment } from "./experiment";
+
+/**
+ * Model of an error response
+ */
+export interface TraceErrorResponse extends ErrorResponse {
+    /**
+     * The experiment that this error corresponds to.
+     */
+    experiment: Experiment;
+}

--- a/tsp-typescript-client/src/models/trace-error-response.ts
+++ b/tsp-typescript-client/src/models/trace-error-response.ts
@@ -1,0 +1,12 @@
+import { ErrorResponse } from "./error-response";
+import { Trace } from "./trace";
+
+/**
+ * Model of an error response
+ */
+export interface TraceErrorResponse extends ErrorResponse {
+    /**
+     * The trace that this error corresponds to.
+     */
+    trace: Trace;
+}

--- a/tsp-typescript-client/src/protocol/rest-client.ts
+++ b/tsp-typescript-client/src/protocol/rest-client.ts
@@ -103,7 +103,7 @@ export class RestClient {
         url: string,
         body?: any,
         normalizer?: Normalizer<T>,
-    ): Promise<TspClientResponse<Deserialized<T>>> {
+    ): Promise<TspClientResponse<Deserialized<T|undefined>>> {
         let response: HttpResponse;
         try {
             response = await this.httpRequest({
@@ -125,6 +125,11 @@ export class RestClient {
         if (response.headers?.get('Content-Type') === 'application/json') {
             try {
                 const parsed = this.jsonParse(response.text);
+
+                // Check if the server sent an error
+                if (response.status >= 400) {
+                     return new TspClientResponse(response.text, response.status, response.statusText, undefined, parsed);
+                }
                 try {
                     const responseModel = normalizer ? normalizer(parsed) : parsed;
                     return new TspClientResponse(response.text, response.status, response.statusText, responseModel);

--- a/tsp-typescript-client/src/protocol/tsp-client-response.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client-response.ts
@@ -1,3 +1,5 @@
+import { ErrorResponse } from "../models/error-response";
+
 /**
  * Trace Server Protocol response.
  * The response includes the response model from the server if available,
@@ -17,6 +19,7 @@ export class TspClientResponse<T> {
         private readonly statusCode: number,
         private readonly statusMessage: string,
         private readonly responseModel?: T,
+        private readonly errorResponse?: ErrorResponse
     ) {}
 
     /**
@@ -45,6 +48,13 @@ export class TspClientResponse<T> {
      */
     public getText(): string {
         return this.text;
+    }
+
+    /**
+     * Returns the error response from the server in an error case 
+     */
+    public getErrorResponse(): ErrorResponse | undefined {
+        return this.errorResponse;
     }
 
     /**

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -574,4 +574,15 @@ describe('HttpTspClient Deserialization', () => {
     const output = response.getModel()!;
     expect(output).toBeDefined();
   });
+
+  it('postTrace-failure', async () => {
+    httpRequestMock.mockResolvedValueOnce({ status: 404, statusText: 'Not Found', text: '{"title": "No trace at /some/path"}', headers: new Headers({ 'Content-Type': 'application/json' }) });
+    const response = await client.openTrace(new Query({}));
+
+    expect(response.getStatusCode()).toEqual(404);
+    expect(response.getStatusMessage()).toEqual('Not Found');
+    expect(response.getText()).toEqual('{"title": "No trace at /some/path"}');
+    expect(response.getModel()).toBeUndefined();
+    expect(response.getErrorResponse()).toEqual({ title: 'No trace at /some/path' });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Return the ErrorResponse message in the getStatusMessage() of TspClientResponse.

Contributes to fix issue:

https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/122

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Code review and use it in a FE (e.g. vscode-trace-extension) and try an example error case, e.g. open trace with file that is not a trace.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
