### PR TITLE
Fix field name to 'required` of ConfigurationParameterDescriptor

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-configuration-sources-0.json
@@ -8,7 +8,7 @@
 				"keyName": "path",
 				"description": "path description",
 				"dataType": "STRING",
-				"isRequired": "True"
+				"required": "True"
  			},
 			{
 				"keyName": "test1"

--- a/tsp-typescript-client/src/models/configuration-source.ts
+++ b/tsp-typescript-client/src/models/configuration-source.ts
@@ -55,5 +55,5 @@ export interface ConfigurationParameterDescriptor {
     /**
      * If parameter needs to in the query parameters or not. Default is false. 
      */
-    isRequired?: boolean;
+    required?: boolean;
 }

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -539,12 +539,12 @@ describe('HttpTspClient Deserialization', () => {
     expect(paramDesc[0].keyName).toEqual('path');
     expect(paramDesc[0].description).toEqual('path description');
     expect(paramDesc[0].dataType).toEqual('STRING');
-    expect(paramDesc[0].isRequired).toBeTruthy();
+    expect(paramDesc[0].required).toBeTruthy();
 
     expect(paramDesc[1].keyName).toEqual('test1');
     expect(paramDesc[1].description).toBeUndefined();
     expect(paramDesc[1].dataType).toBeUndefined();
-    expect(paramDesc[1].isRequired).toBeUndefined();
+    expect(paramDesc[1].required).toBeUndefined();
     expect(sourceTypes[0].schema).toBeUndefined();
 
     expect(sourceTypes[1].parameterDescriptors).toBeUndefined();


### PR DESCRIPTION
The TSP specifies `required` instead of `isRequired`. This commit aligns the implementation with the specification.



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Fix field name to 'required` of ConfigurationParameterDescriptor. The TSP specifies `required` instead of `isRequired`. This commit aligns the implementation with the specification.

See also:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/issues/246

<!-- Include relevant issues and describe how they are addressed. -->

### How to test
There is on unit test in this repo that verifies this (`configurationSourceTypes` of `tsp-client-tests.ts`) which should run successfully now.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
