### PR TITLE
Support generic object data provider

### DIFF
--- a/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/experiment-outputs-0.json
@@ -12,7 +12,7 @@
 		"type": "TABLE"
 	},
 	{
-		"id": "data.output.id",
+		"id": "datatree.output.id",
 		"name": "Output name",
 		"description": "Output description",
 		"type": "DATA_TREE"
@@ -51,6 +51,15 @@
 		"capabilities": {
 			"canCreate": false,
 			"canDelete": true
+		}
+	},
+	{
+		"id": "data.output.id",
+		"name": "Output name",
+		"description": "Output description",
+		"type": "DATA",
+		"capabilities": {
+			"selectionRange": true
 		}
 	}
 ]

--- a/tsp-typescript-client/fixtures/tsp-client/fetch-object-0.json
+++ b/tsp-typescript-client/fixtures/tsp-client/fetch-object-0.json
@@ -1,0 +1,16 @@
+{
+	"model": {
+		"object": {
+				"fooNumber": 1234567890123456789,
+				"fooString": "foo",
+				"fooObj": { "fooA": { "A1key": "A1val", "A2key": 1 },
+							"fooB": { "B1key": "B1val", "B2key": 2 } },
+				"fooNumArray": [1, 2, 3],
+				"fooObjArray": [{"k": "v1"}, {"k": "v2"}, {"k": "v3"}]
+			},
+		"next": 9876543210987654321,
+		"previous": { "rank": 0 }
+	},
+	"statusMessage": "Completed",
+	"status": "COMPLETED"
+}

--- a/tsp-typescript-client/src/models/object.ts
+++ b/tsp-typescript-client/src/models/object.ts
@@ -1,0 +1,27 @@
+import { createNormalizer } from '../protocol/serialization';
+
+export const ObjectModel = createNormalizer<ObjectModel>({
+    object: undefined,
+    next: undefined,
+    previous: undefined
+});
+
+/**
+ * Object model that will be returned by the server
+ */
+export interface ObjectModel {
+    /**
+     * Generic object
+     */
+    object: any;
+
+    /**
+     * Next navigation parameter object
+     */
+    next?: any;
+
+    /**
+     * Previous navigation parameter object
+     */
+    previous?: any;
+}

--- a/tsp-typescript-client/src/models/output-capabilities.ts
+++ b/tsp-typescript-client/src/models/output-capabilities.ts
@@ -5,6 +5,9 @@
  * "canCreate" indicates that a given data provider can create a derived data
  * provider. "canDelete" indicates that a given data provider can be deleted.
  * 
+ * "selectionRange" indicates that a given data provider can use the selection
+ * range to compute its data. Clients should include the selection range in
+ * query parameters and refresh the data when the selection range changes.
  */
 export class OutputCapabilities {
     /**
@@ -16,4 +19,9 @@ export class OutputCapabilities {
      * Whether the data provider can be deleted. 'false' if absent.
      */
     canDelete?: boolean;
+
+    /**
+     * Whether the data provider uses the selection range. 'false' if absent.
+     */
+    selectionRange?: boolean;
 }

--- a/tsp-typescript-client/src/models/output-descriptor.ts
+++ b/tsp-typescript-client/src/models/output-descriptor.ts
@@ -43,6 +43,10 @@ export enum ProviderType {
      * A provider for a gantt chart (abitrary x-axis). E.g. flame graph.
      */
     GANTT_CHART = "GANTT_CHART",
+    /**
+     * A provider of generic data objects.
+     */
+    DATA = "DATA",
 }
 
 /**

--- a/tsp-typescript-client/src/protocol/http-tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/http-tsp-client.ts
@@ -13,6 +13,7 @@ import { MarkerSet } from "../models/markerset";
 import { OutputDescriptor } from "../models/output-descriptor";
 import { ConfigurationQuery, OutputConfigurationQuery, Query } from "../models/query/query";
 import { GenericResponse } from "../models/response/responses";
+import { ObjectModel } from "../models/object";
 import { OutputStyleModel } from "../models/styles";
 import { ColumnHeaderEntry, TableModel } from "../models/table";
 import {
@@ -165,6 +166,32 @@ export class HttpTspClient implements ITspClient {
     ): Promise<TspClientResponse<OutputDescriptor[]>> {
         const url = this.baseUrl + "/experiments/" + expUUID + "/outputs";
         return RestClient.get(url, undefined, array(OutputDescriptor));
+    }
+
+    /**
+     * Fetch object
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic object response
+     */
+    public async fetchObject(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<ObjectModel>>> {
+        const url =
+            this.baseUrl +
+            "/experiments/" +
+            expUUID +
+            "/outputs/data/" +
+            outputID +
+            "/obj";
+        return RestClient.post(
+            url,
+            parameters,
+            GenericResponse(ObjectModel)
+        );
     }
 
     /**

--- a/tsp-typescript-client/src/protocol/tsp-client.test.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.test.ts
@@ -126,7 +126,7 @@ describe('HttpTspClient Deserialization', () => {
     httpRequestMock.mockReturnValueOnce(fixtures.asResponse('experiment-outputs-0.json'));
     const response = await client.experimentOutputs('not-relevant');
     const outputs = response.getModel()!;
-    expect(outputs).toHaveLength(6);
+    expect(outputs).toHaveLength(7);
 
     let output = outputs.find((item) => item.id === 'timegraph.output.id1');
     expect(output).toBeDefined();
@@ -141,6 +141,11 @@ describe('HttpTspClient Deserialization', () => {
     expect(output?.capabilities?.canCreate).toBeFalsy();
     expect(output?.capabilities?.canDelete).toBeTruthy();
     expect(output?.configuration).toBeDefined();
+
+    output = outputs.find((item) => item.id === 'data.output.id');
+    expect(output).toBeDefined();
+    expect(output?.capabilities).toBeDefined();
+    expect(output?.capabilities?.selectionRange).toBeTruthy();
   });
 
   it('fetchAnnotationsCategories', async () => {
@@ -208,6 +213,27 @@ describe('HttpTspClient Deserialization', () => {
     expect(identifier.cpuCount).toBeDefined();
     expect(identifier.maxMemory).toBeDefined();
     expect(identifier.productId).toBeDefined();
+  });
+
+  it('fetchObject', async () => {
+    httpRequestMock.mockReturnValueOnce(fixtures.asResponse('fetch-object-0.json'));
+    const response = await client.fetchObject('not-relevant', 'not-relevant', new Query({}));
+    const genericResponse = response.getModel()!;
+    const object = genericResponse.model.object;
+    const next = genericResponse.model.next;
+    const previous = genericResponse.model.previous;
+
+    expect(object).toBeDefined();
+    expect(object['fooNumber']).toEqual(BigInt('1234567890123456789'));
+    expect(object['fooString']).toEqual('foo');
+    expect(object['fooObj']['fooA']).toEqual({ "A1key": "A1val", "A2key": 1 });
+    expect(object['fooObj']['fooB']).toEqual({ "B1key": "B1val", "B2key": 2 });
+    expect(object['fooNumArray']).toEqual([1, 2, 3]);
+    expect(object['fooObjArray']).toEqual([{"k": "v1"}, {"k": "v2"}, {"k": "v3"}]);
+    expect(next).toBeDefined();
+    expect(next).toEqual(BigInt('9876543210987654321'));
+    expect(previous).toBeDefined();
+    expect(previous).toEqual({ "rank": 0 });
   });
 
   it('fetchMarkerSets', async () => {

--- a/tsp-typescript-client/src/protocol/tsp-client.ts
+++ b/tsp-typescript-client/src/protocol/tsp-client.ts
@@ -16,6 +16,7 @@ import { Experiment } from "../models/experiment";
 import { OutputDescriptor } from "../models/output-descriptor";
 import { EntryModel } from "../models/entry";
 import { TspClientResponse } from "./tsp-client-response";
+import { ObjectModel } from "../models/object";
 import { OutputStyleModel } from "../models/styles";
 import { HealthStatus } from "../models/health";
 import { MarkerSet } from "../models/markerset";
@@ -110,6 +111,19 @@ export interface ITspClient {
     experimentOutputs(
         expUUID: string
     ): Promise<TspClientResponse<OutputDescriptor[]>>;
+
+    /**
+     * Fetch object
+     * @param expUUID Experiment UUID
+     * @param outputID Output ID
+     * @param parameters Query object
+     * @returns Generic object response
+     */
+    fetchObject(
+        expUUID: string,
+        outputID: string,
+        parameters: Query
+    ): Promise<TspClientResponse<GenericResponse<ObjectModel>>>;
 
     /**
      * Fetch Data tree

--- a/tsp-typescript-client/src/utils/jsonbig-utils.ts
+++ b/tsp-typescript-client/src/utils/jsonbig-utils.ts
@@ -42,7 +42,7 @@ export class JSONBigUtils {
     /**
      * Stringify JS objects. Can stringify `BigInt` values.
      */
-    public static stringify(data: any): string {
-        return JSONBig.stringify(data);
+    public static stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string {
+        return JSONBig.stringify(value, replacer, space);
     }
 }


### PR DESCRIPTION
### What it does

Implement fetchObject for /obj endpoint

Add ObjectModel for response

Add selectionRange to OutputCapabilities

Add optional replacer and space arguments to JSONBigUtils.stringify

Add unit tests

### How to test

Fetch data from new endpoint

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
